### PR TITLE
added support to disable consul as a backend

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ consul_template_do_not_start_immediately: true
 
 ##########
 ##  Config
+consul_template_consul_enable: true
 consul_template_consul_auth: {}       # See example below
 consul_template_consul_address: '127.0.0.1:8500'
 consul_template_consul_token:

--- a/templates/defaults.conf.j2
+++ b/templates/defaults.conf.j2
@@ -1,3 +1,4 @@
+{% if consul_template_consul_enable|default(true) %}
 consul {
 {% if consul_template_consul_auth %}
   auth {
@@ -35,6 +36,7 @@ consul {
   }
 {% endif -%}
 }
+{% endif -%}
 
 reload_signal = "{{ consul_template_reload_signal|default('SIGHUP') }}"
 


### PR DESCRIPTION
Previously there was no way to only use vault as a backend for consul-template.  To prevent a breaking change if consul_template_consul_enable is not defined it is assumed to be true.